### PR TITLE
Handle Quickcheck timeouts during synthesis

### DIFF
--- a/src/synthesis/synth_prf_tools.ML
+++ b/src/synthesis/synth_prf_tools.ML
@@ -30,7 +30,8 @@ fun counter_ex_check ctxt trm =
       case (CounterExCInfo.quickcheck_term ctxt (quickcheck_params, []) trm1) of
         NONE => SOME trm | SOME cex => NONE
     end
-    handle ERROR _ => SOME trm;
+    handle ERROR _           => SOME trm
+         | TimeLimit.TimeOut => SOME trm;
 
 (* Counter-example checking with a counter that counts non-theorems *)
 fun counter_ex_check_count  counter_ex_counter_ref ctxt trm0 =


### PR DESCRIPTION
I was getting `TimeOut` exceptions when stress-testing IsaCoSy on large inputs (~100 functions), which I traced back to Quickcheck.

Looking through the existing logic I see we're looking for counter-examples of a given term, *with* a time limit but *not* interactively. Quickcheck is called with a timeout handler, which would print out a "timed out" message; but since we're non-interactive, the logic says to *ignore* the handler and reraise the `TimeOut` exception. It reaches the synthesis/IsaCoSy level, which doesn't handle it, and ultimately (in my case) it reaches the PolyML REPL and aborts. The timing stats given out by Isabelle seem to reach around 350 seconds before this happens, although we actually call Quickcheck over and over so the actual limit will be smaller than that.

If we look at the way Quickcheck is being used: if a counter-example is found we return `NONE` to indicate that we don't have a plausible statement, at which point synthesis moves on to another term. If *no* counter-example is found, we return the term (wrapped in `SOME`) since it remains plausible (not disproved). The interesting thing is if Quickcheck encounters an error: we catch it and return the term, just as if Quickcheck had finished normally with no counterexamples found.

What this patch does is add an extra handler to catch timeouts, which acts like the error handler (returning the term, since we weren't able to disprove it).

I've run my stress-test against this version of IsaPlanner and it doesn't hit the timeout problem any more. Instead, it runs for about an hour, then aborts with an `Interrupt` due to lack of memory. I think that's a perfectly reasonable behaviour (although maybe a more informative name would be nice, like `OutOfMemory`; I tried to add this to my code but I kept hitting newbie syntax errors and things, since I've never used ML before ;) ).